### PR TITLE
feat: add delfin command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ version = "0.1.0"
 dependencies = [
  "json",
  "poise",
+ "rand",
  "regex",
  "reqwest 0.12.4",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 json = "0.12.4"
 poise = "0.6.1"
+rand = "0.8.5"
 regex = "1.10.4"
 reqwest = "0.12.4"
 tokio = { version = "1.37.0", features = ["full"] }

--- a/resources/dolphins.txt
+++ b/resources/dolphins.txt
@@ -1,0 +1,7 @@
+https://apartments-cres-losinj.com/sites/9191/upload/pages/1461055926_delfini.jpg
+https://as2.ftcdn.net/jpg/01/63/15/07/500_F_163150750_EiE3ZLacp47ar2xA1b2A4OLyKgR7MGNR.jpg
+https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcS3kwy1ZTjrOdy97nDV0qxI5BHp8R6rxizOgfTVhhGlpTZn7Tjc
+https://perryponders.com/wp-content/uploads/2017/07/dolphin.jpg
+https://static.independent.co.uk/s3fs-public/thumbnails/image/2015/08/19/14/dolphin.jpg?w968h681
+https://www.delphinschutz.org/wp-content/uploads/2017/12/Patendelfin_Magic_Rotes_Meer.jpg
+https://www.news.at/_storage/asset/4212532/storage/newsat:key-visual/file/56424572/Delfin.jpg

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,8 @@
+#[derive(Debug)]
+pub struct NoDolphinError;
+impl std::fmt::Display for NoDolphinError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "no dolphin found")
+    }
+}
+impl std::error::Error for NoDolphinError {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,7 @@
+mod errors;
 mod token;
+
+use crate::errors::NoDolphinError;
 
 use std::{
     fs::File,
@@ -125,8 +128,7 @@ async fn delfin(ctx: Context<'_>) -> Result<(), Error> {
     let dolphin = f
         .lines()
         .choose(&mut rand::thread_rng())
-        // TODO: handle None case
-        .expect("no dolphin found")?;
+        .ok_or(NoDolphinError)??;
     ctx.say(dolphin).await?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,10 @@
 mod token;
 
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+};
+
 use poise::{
     serenity_prelude::{
         self as serenity, Color, CreateAttachment, CreateEmbed, CreateEmbedAuthor,
@@ -7,6 +12,7 @@ use poise::{
     },
     CreateReply, Prefix, PrefixFrameworkOptions,
 };
+use rand::seq::IteratorRandom;
 use reqwest::Response;
 use token::TOKEN;
 
@@ -14,6 +20,9 @@ use token::TOKEN;
 struct Data {} // User data, which is stored and accessible in all command invocations
 type Error = Box<dyn std::error::Error + Send + Sync>;
 type Context<'a> = poise::Context<'a, Data, Error>;
+
+// TODO: maybe improve this as this path is relative to the current working directory
+const DOLPHIN_PATH: &str = "./resources/dolphins.txt";
 
 /// alfred cat
 ///
@@ -108,6 +117,20 @@ async fn define(
     Ok(())
 }
 
+/// alfred delfin
+#[poise::command(slash_command, prefix_command, track_edits)]
+async fn delfin(ctx: Context<'_>) -> Result<(), Error> {
+    let f = File::open(DOLPHIN_PATH)?;
+    let f = BufReader::new(f);
+    let dolphin = f
+        .lines()
+        .choose(&mut rand::thread_rng())
+        // TODO: handle None case
+        .expect("no dolphin found")?;
+    ctx.say(dolphin).await?;
+    Ok(())
+}
+
 /// alfred eminem
 #[poise::command(slash_command, prefix_command, track_edits)]
 async fn eminem(ctx: Context<'_>) -> Result<(), Error> {
@@ -135,7 +158,7 @@ async fn main() {
     let framework = poise::Framework::builder()
         // set options
         .options(poise::FrameworkOptions {
-            commands: vec![cat(), define(), eminem(), kleanthis()],
+            commands: vec![cat(), define(), delfin(), eminem(), kleanthis()],
             // set up prefix
             prefix_options: PrefixFrameworkOptions {
                 prefix: Some(String::from("alfred")),


### PR DESCRIPTION
Closes #2 
The initial images have been collected by querying Alfred a few times.
The command will select a random image link from the given list and send it.

**More images will always be welcome, feel free to open a pull request to add more!**

Also, if you find an API that could provide the images without maintenance on my side, feel free to open an issue for that, I'd happily rework the command to poll it instead.
TODO:
- [x] Add some initial images
- [x] Implement the command logic